### PR TITLE
Replaced occurences of python with explicit python2 calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.so
 *.aux
 *.pdf
+log/

--- a/BUGDETAILS
+++ b/BUGDETAILS
@@ -34,5 +34,3 @@ fixed.
   - From now on this case is handled properly.
 
   This bug was fixed in 1.0-fix1.
-
-

--- a/UPGRADE
+++ b/UPGRADE
@@ -18,4 +18,3 @@ a new install with 1.4.x.
 
 
   Frank Lübeck
-

--- a/cryptpasswd
+++ b/cryptpasswd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -4,7 +4,7 @@
 
 \parindent0.0em
 \setlength{\parskip}{0.7ex plus 1.0ex}
-\usepackage[latin1]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage{times}
 \usepackage{calc}
 \usepackage{a4wide}
@@ -19,7 +19,7 @@
 
 \begin{document}
 \title{\Huge \textbf {\OKUSON} Manual}
-\author{Frank Lübeck\\Max Neunhöffer \\[2cm] Version \input{../VERSION}}
+\author{Frank LÃ¼beck\\Max NeunhÃ¶ffer \\[2cm] Version \input{../VERSION}}
 \maketitle
 \tableofcontents
 
@@ -30,7 +30,7 @@ This software package may be freely distributed under the terms of the
 GNU Public License, see chapter~\ref{ch:GPL} for the details of that
 license.
 
-\copyright\  (2003,2004) Frank Lübeck and Max Neunhöffer
+\copyright\  (2003,2004) Frank LÃ¼beck and Max NeunhÃ¶ffer
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -60,8 +60,8 @@ experiences can be found in the article:
 
 \begin{center}
 \begin{minipage}{\textwidth-1in}
-   Frank Lübeck und Max Neunhöffer,
-\href{http://www.math.rwth-aachen.de:8001/~Frank.Luebeck/preprints/AufgServCARweb.pdf}{Übungsbetrieb über Webservice}, \href{http://www.fachgruppe-computeralgebra.de/CAR}{Computer Algebra Rundbrief} \textbf{31}, Oktober 2002
+   Frank LÃ¼beck und Max NeunhÃ¶ffer,
+\href{http://www.math.rwth-aachen.de:8001/~Frank.Luebeck/preprints/AufgServCARweb.pdf}{Ãœbungsbetrieb Ã¼ber Webservice}, \href{http://www.fachgruppe-computeralgebra.de/CAR}{Computer Algebra Rundbrief} \textbf{31}, Oktober 2002
 \end{minipage}
 \end{center}
 
@@ -145,16 +145,16 @@ XML, CSS, and lots of other technologies.
 \item Robin Becker and his colleagues at ReportLab Inc.~for providing
 Python bindings for \textsf{RXP} in form of the Python extension module
 \texttt{pyRXP}.
-\item Thorsten Heck from Lehrstuhl A für Mathematik (RWTH Aachen) for
+\item Thorsten Heck from Lehrstuhl A fÃ¼r Mathematik (RWTH Aachen) for
 contributing statistic functions for the administrator menu.
-\item Ingo Klöcker from Lehrstuhl A für Mathematik (RWTH Aachen) for
+\item Ingo KlÃ¶cker from Lehrstuhl A fÃ¼r Mathematik (RWTH Aachen) for
 contributing patches and bugfixes.
-\item Volker Dietrich, Thorsten Heck, Ingo Klöcker, and Axel Marschner for
+\item Volker Dietrich, Thorsten Heck, Ingo KlÃ¶cker, and Axel Marschner for
 using (and testing) {\OKUSON} even before the first official release and
 for the valuable hints and suggestions during Wintersemester 2003/04.
-\item Marc Ensenbach from Lehrstuhl A für Mathematik (RWTH Aachen) for 
+\item Marc Ensenbach from Lehrstuhl A fÃ¼r Mathematik (RWTH Aachen) for 
     contributing the code for the free form homework input page.
-\item Ingo Klöcker for contributing the extension framework plus the first
+\item Ingo KlÃ¶cker for contributing the extension framework plus the first
     few plugins.
 \item All the others who have been forgotten in this list.
 \end{itemize}
@@ -2159,7 +2159,7 @@ all participants for a certain sheet.
 \subsection{Show Exercise Statistics for sheet}
 
 \textbf{The code for this and the following four statistic functions was kindly
-contributed by Thorsten Heck and Ingo Klöcker from Lehrstuhl A für
+contributed by Thorsten Heck and Ingo KlÃ¶cker from Lehrstuhl A fÃ¼r
 Mathematik, RWTH Aachen.}
 \bigskip
 

--- a/makeArchive
+++ b/makeArchive
@@ -54,4 +54,3 @@ rm -f makeArchive
 cd ..
 mv OKUSON okuson
 tar czvf okuson-`cat okuson/VERSION`.tar.gz --exclude='.nfs*' okuson
-

--- a/scripts/RWTHCampus2people.py
+++ b/scripts/RWTHCampus2people.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2010 by  Frank Lübeck  and   Max Neunhöffer

--- a/scripts/RWTHLehrevaluationMessages.py
+++ b/scripts/RWTHLehrevaluationMessages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2005 by  Frank Lübeck  and   Max Neunhöffer

--- a/scripts/SendEmails.py
+++ b/scripts/SendEmails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2010 by  Frank Lübeck  and   Max Neunhöffer

--- a/scripts/SendInitPasswords.py
+++ b/scripts/SendInitPasswords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2010 by  Frank Lübeck  and   Max Neunhöffer

--- a/scripts/distribute.py
+++ b/scripts/distribute.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2003 by  Frank Lübeck  and   Max Neunhöffer

--- a/scripts/dumpsubmissions.py
+++ b/scripts/dumpsubmissions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 # 
 #   Copyright (C) 2007 by  Frank Lübeck

--- a/scripts/exampleMailSendInitPasswords
+++ b/scripts/exampleMailSendInitPasswords
@@ -29,4 +29,3 @@ Mit freundlichen Grüßen,
 
 --
 *   Frank.Luebeck@Math.RWTH-Aachen.de, Templergraben 64 (Raum 202)
-

--- a/scripts/getexamresults.py
+++ b/scripts/getexamresults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2007 by  Frank Lübeck

--- a/scripts/logrotate.py
+++ b/scripts/logrotate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/scripts/makestickers.py
+++ b/scripts/makestickers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/scripts/makesum.py
+++ b/scripts/makesum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/scripts/numbergroups.py
+++ b/scripts/numbergroups.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2003 by  Frank Lübeck  and   Max Neunhöffer

--- a/scripts/okusonarchive
+++ b/scripts/okusonarchive
@@ -7,4 +7,3 @@ DIRNAME="..."
 cd $BACKUPDIR
 fname=`date +"BACKUP-%Y-%m-%d_%H_%M_%S.tgz"`
 tar czf $fname $DIRNAME
-

--- a/scripts/prettyprintgroupdist.py
+++ b/scripts/prettyprintgroupdist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2003 by  Frank Lübeck  and   Max Neunhöffer

--- a/scripts/schein.py
+++ b/scripts/schein.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/scripts/sortselect.py
+++ b/scripts/sortselect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/scripts/startNOSERVER.py
+++ b/scripts/startNOSERVER.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2010 by  Frank Lübeck  and   Max Neunhöffer

--- a/server/Restart.py
+++ b/server/Restart.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/server/Server.py
+++ b/server/Server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/server/Stop.py
+++ b/server/Stop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/server/TestExercise.py
+++ b/server/TestExercise.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/server/TestSheet.py
+++ b/server/TestSheet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/server/WebWorkers.py
+++ b/server/WebWorkers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #  OKUSON Package
 #  Frank Lübeck and Max Neunhöffer

--- a/server/fmTools/SimpleTemplate.py
+++ b/server/fmTools/SimpleTemplate.py
@@ -1,5 +1,5 @@
 # -*- coding: ISO-8859-1 -*-
-#!/usr/bin/env python
+#!/usr/bin/env python2
 ##  SimpleTemplate.g                              
 ##  
 ##  

--- a/server/makepyRXP
+++ b/server/makepyRXP
@@ -5,7 +5,7 @@ if [ ! -x pyRXP ]; then
 fi
 
 cd pyRXP
-python setup.py build_ext
+python2 setup.py build_ext
 cp "`find build -name pyRXP.so`" ..
 cp "`find build -name pyRXPU.so`" ..
 cd ..
@@ -17,5 +17,4 @@ echo You should find two files \"pyRXP.so\" and \"pyRXPU.so\" in this
 echo directory. Otherwise, please look for error messages above.
 
 exit
-
 

--- a/start
+++ b/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2003 by  Frank Lübeck  and   Max Neunhöffer

--- a/stop
+++ b/stop
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2003 by  Frank Lübeck  and   Max Neunhöffer

--- a/test/miniclient.py
+++ b/test/miniclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import socket
 

--- a/test/miniserver.py
+++ b/test/miniserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import socket,threading
 

--- a/test/stresstest
+++ b/test/stresstest
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os,sys,httplib, time, random
 

--- a/testexercise
+++ b/testexercise
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2003 by  Frank Lübeck  and   Max Neunhöffer

--- a/testsheet
+++ b/testsheet
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2003 by  Frank Lübeck  and   Max Neunhöffer

--- a/xmlvalidate
+++ b/xmlvalidate
@@ -1,4 +1,4 @@
-#!/usr/bin/env    python
+#!/usr/bin/env    python2
 # -*- coding: ISO-8859-1 -*-
 #
 #   Copyright (C) 2003 by  Frank Lübeck  and   Max Neunhöffer


### PR DESCRIPTION
For some OS, `python` is linked to `python3` instead of `python2`, causing errors in the build process.

Also, a minor change in the manual's encding from latin1 to utf8.