### PR TITLE
Add not displayed id field on sheet page

### DIFF
--- a/html.english/sheet.tpl
+++ b/html.english/sheet.tpl
@@ -71,6 +71,9 @@
      
      <IfIndividualSheets>
      <IfOpen>
+      <p style="display:none;">ID: 
+        <input type="text" class="short"  maxlength="6" name="namedummy" value="" />         
+      </p>
       <p>Password:
          <input type="password" class="short" maxlength="16" name="passwd"
                 value="" />

--- a/html/sheet.tpl
+++ b/html/sheet.tpl
@@ -70,6 +70,9 @@
      </IfMathJax>
      <IfIndividualSheets>
      <IfOpen>
+      <p style="display:none;">Matrikelnummer: 
+        <input type="text" class="short"  maxlength="6" name="namedummy" value="" />         
+      </p>
       <p>Passwort:
          <input type="password" class="short" maxlength="16" name="passwd"
                 value="" />


### PR DESCRIPTION
Fixes the second error described in #9 with an XHTML compliant patch.

The visible page will be the same as before on most browsers,
but now common password managers won't insert the students id
into the last excercise field.